### PR TITLE
[§1] Rozszerzenie modelu Order/AgentDecision/SimulationConfig (#2)

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -3,20 +3,32 @@
 from core.env import MarketEnv, PoissonNoiseGenerator
 from core.interfaces import MatchingEngineProtocol, coerce_snapshot
 from core.mock_engine import MockMatchingEngine
-from core.models import AgentDecision, Level, MarketSnapshot, Order, SimulationConfig
+from core.models import (
+    AgentDecision,
+    Level,
+    MarketPhase,
+    MarketSnapshot,
+    Order,
+    PriceType,
+    SimulationConfig,
+    TimeInForce,
+)
 from core.real_engine import RealEngineAdapterConfig, RealMatchingEngineAdapter
 
 __all__ = [
     "AgentDecision",
     "Level",
     "MarketEnv",
+    "MarketPhase",
     "MarketSnapshot",
     "MatchingEngineProtocol",
     "MockMatchingEngine",
     "Order",
     "PoissonNoiseGenerator",
+    "PriceType",
     "RealEngineAdapterConfig",
     "RealMatchingEngineAdapter",
     "SimulationConfig",
+    "TimeInForce",
     "coerce_snapshot",
 ]

--- a/core/models.py
+++ b/core/models.py
@@ -10,8 +10,44 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 OrderAction = Literal["buy", "sell"]
 DecisionAction = Literal["buy", "sell", "hold"]
-PriceType = Literal["market", "limit"]
-OrderSource = Literal["rl", "swarm", "system"]
+PriceType = Literal["market", "limit", "stop_market", "stop_limit"]
+OrderSource = Literal["rl", "swarm", "system", "institutional", "accumulation", "noise"]
+TimeInForce = Literal["GTC", "IOC", "FOK", "GTD"]
+MarketPhase = Literal["pre_open", "opening_auction", "continuous", "closing_auction", "closed"]
+
+
+def _validate_price_fields(
+    price_type: PriceType,
+    limit_price: float | None,
+    stop_price: float | None,
+) -> None:
+    if price_type == "market":
+        if limit_price is not None:
+            raise ValueError("limit_price must be omitted when price_type='market'.")
+        if stop_price is not None:
+            raise ValueError("stop_price must be omitted when price_type='market'.")
+    elif price_type == "limit":
+        if limit_price is None:
+            raise ValueError("limit_price is required when price_type='limit'.")
+        if stop_price is not None:
+            raise ValueError("stop_price must be omitted when price_type='limit'.")
+    elif price_type == "stop_market":
+        if stop_price is None:
+            raise ValueError("stop_price is required when price_type='stop_market'.")
+        if limit_price is not None:
+            raise ValueError("limit_price must be omitted when price_type='stop_market'.")
+    elif price_type == "stop_limit":
+        if stop_price is None:
+            raise ValueError("stop_price is required when price_type='stop_limit'.")
+        if limit_price is None:
+            raise ValueError("limit_price is required when price_type='stop_limit'.")
+
+
+def _validate_time_in_force(time_in_force: TimeInForce, expiry_tick: int | None) -> None:
+    if time_in_force == "GTD" and expiry_tick is None:
+        raise ValueError("expiry_tick is required when time_in_force='GTD'.")
+    if time_in_force != "GTD" and expiry_tick is not None:
+        raise ValueError("expiry_tick must be omitted unless time_in_force='GTD'.")
 
 
 class Level(BaseModel):
@@ -32,16 +68,17 @@ class Order(BaseModel):
     price_type: PriceType = "market"
     volume: float = Field(gt=0.0)
     limit_price: float | None = Field(default=None, ge=0.0)
+    stop_price: float | None = Field(default=None, ge=0.0)
+    time_in_force: TimeInForce = "GTC"
+    expiry_tick: int | None = Field(default=None, ge=0)
     agent_id: str | None = None
     source: OrderSource = "system"
     timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
     @model_validator(mode="after")
-    def validate_limit_fields(self) -> "Order":
-        if self.price_type == "limit" and self.limit_price is None:
-            raise ValueError("limit_price is required when price_type='limit'.")
-        if self.price_type == "market" and self.limit_price is not None:
-            raise ValueError("limit_price must be omitted when price_type='market'.")
+    def validate_price_fields(self) -> "Order":
+        _validate_price_fields(self.price_type, self.limit_price, self.stop_price)
+        _validate_time_in_force(self.time_in_force, self.expiry_tick)
         return self
 
 
@@ -54,6 +91,9 @@ class AgentDecision(BaseModel):
     price_type: PriceType = "market"
     volume: float = Field(default=0.0, ge=0.0)
     limit_price: float | None = Field(default=None, ge=0.0)
+    stop_price: float | None = Field(default=None, ge=0.0)
+    time_in_force: TimeInForce = "GTC"
+    expiry_tick: int | None = Field(default=None, ge=0)
     confidence: float | None = Field(default=None, ge=0.0, le=1.0)
     rationale: str | None = None
     agent_id: str | None = None
@@ -66,14 +106,16 @@ class AgentDecision(BaseModel):
                 raise ValueError("Hold decisions must have volume=0.")
             if self.limit_price is not None:
                 raise ValueError("Hold decisions cannot set limit_price.")
+            if self.stop_price is not None:
+                raise ValueError("Hold decisions cannot set stop_price.")
+            if self.expiry_tick is not None:
+                raise ValueError("Hold decisions cannot set expiry_tick.")
             return self
 
         if self.volume <= 0.0:
             raise ValueError("Trade decisions must have positive volume.")
-        if self.price_type == "limit" and self.limit_price is None:
-            raise ValueError("Limit decisions must include limit_price.")
-        if self.price_type == "market" and self.limit_price is not None:
-            raise ValueError("Market decisions cannot include limit_price.")
+        _validate_price_fields(self.price_type, self.limit_price, self.stop_price)
+        _validate_time_in_force(self.time_in_force, self.expiry_tick)
         return self
 
     def to_order(self) -> Order | None:
@@ -86,6 +128,9 @@ class AgentDecision(BaseModel):
             price_type=self.price_type,
             volume=self.volume,
             limit_price=self.limit_price,
+            stop_price=self.stop_price,
+            time_in_force=self.time_in_force,
+            expiry_tick=self.expiry_tick,
             agent_id=self.agent_id,
             source=self.source,
         )
@@ -103,6 +148,7 @@ class MarketSnapshot(BaseModel):
     imbalance: float = Field(ge=-1.0, le=1.0)
     spread: float = Field(ge=0.0)
     tick: int = Field(default=0, ge=0)
+    phase: MarketPhase = "continuous"
     timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
     def to_observation_vector(self, depth_levels: int) -> np.ndarray:
@@ -140,4 +186,23 @@ class SimulationConfig(BaseModel):
     noise_warmup_steps: int = Field(default=10, ge=0)
     reward_inventory_penalty: float = Field(default=0.001, ge=0.0)
     transaction_cost_bps: float = Field(default=0.0, ge=0.0)
+    commission_bps: float = Field(default=0.0, ge=0.0)
+    commission_min_per_trade: float = Field(default=0.0, ge=0.0)
+    ticks_per_session: int = Field(default=1000, gt=0)
+    sessions_per_year: int = Field(default=252, gt=0)
+    cycles_per_session: int = Field(default=40, gt=0)
+    opening_auction_ticks: int = Field(default=20, ge=0)
+    closing_auction_ticks: int = Field(default=20, ge=0)
+    accumulation_days: int = Field(default=5, gt=0)
+    accumulation_volume: float = Field(default=1.0, gt=0.0)
+    session_schedule: list[tuple[str, int]] | None = None
     random_seed: int | None = None
+
+    @model_validator(mode="after")
+    def validate_auction_windows(self) -> "SimulationConfig":
+        total_auction = self.opening_auction_ticks + self.closing_auction_ticks
+        if total_auction >= self.ticks_per_session:
+            raise ValueError(
+                "opening_auction_ticks + closing_auction_ticks must be < ticks_per_session."
+            )
+        return self

--- a/docs/project_baseline.md
+++ b/docs/project_baseline.md
@@ -206,14 +206,33 @@ One cycle follows this sequence:
 
 ```mermaid
 flowchart TD
-    fastLane[FastLaneTicks] --> snapshot[MarketSnapshot]
-    snapshot --> slowLane[SwarmManager]
-    marketNews[MarketNews] --> slowLane
-    slowLane --> decisions[ValidatedDecisions]
-    decisions --> orders[SwarmOrders]
-    orders --> inject[InjectAsMarketOrders]
-    inject --> fastLane
+    subgraph fastLane[Fast Lane per tick]
+        rlAgent[RL Agent] --> lob[Matching Engine]
+        institutional[Institutional MM] --> lob
+        accumulation[Accumulation Investor] --> lob
+        noise[Poisson Noise] --> lob
+        stopQueue[Stop Order Queue] --> lob
+        lob --> phases[Session Phase Manager]
+        phases --> lob
+    end
+    lob --> snapshot[MarketSnapshot + phase + tick]
+    snapshot --> orchestrator[SimulationOrchestrator]
+    newsFeed[NewsFeed / External Events] --> orchestrator
+    orchestrator -->|every N cycles or on event| slowLane[SwarmManager]
+    marketNews[Market News string] --> slowLane
+    slowLane --> decisions[Validated AgentDecisions]
+    decisions --> orders[Swarm Orders]
+    orders --> broker[Broker / CommissionModel]
+    broker --> inject[Inject into LOB]
+    inject --> lob
 ```
+
+The diagram reflects the extended system after the April 2026 supervisor
+feedback round: stop-order wrappers, accumulation investors, the session
+phase manager with opening and closing auctions, the broker commission
+layer, and the external news feed are all wired into the same orchestrator
+loop. Orders carry `price_type ∈ {market, limit, stop_market, stop_limit}`,
+`time_in_force ∈ {GTC, IOC, FOK, GTD}`, and an optional `expiry_tick`.
 
 ### Why Force Market Orders On Injection?
 

--- a/docs/running_and_flow.md
+++ b/docs/running_and_flow.md
@@ -237,15 +237,37 @@ The clean architecture for experiments is:
 
 ```mermaid
 flowchart TD
-    rlAgent[RLAgent] --> lob[LimitOrderBook]
-    institutionAgent[InstitutionalAgent] --> lob
-    noiseAgent[ZeroIntelligenceNoise] --> lob
-    lob --> snapshot[MarketSnapshot]
-    marketNews[MarketNews] --> swarm[LLMSwarm]
+    rlAgent[RL Agent] --> lob[Python LOB Engine]
+    institutionAgent[Institutional MM] --> lob
+    accumulation[Accumulation Investor<br/>DCA every 5 sessions] --> lob
+    noiseAgent[Zero-Intelligence Noise] --> lob
+    stopQueue[Stop Order Queue<br/>stop_market / stop_limit] -->|released on trigger| lob
+    phases[Session Phase Manager<br/>opening auction / continuous / closing auction] -->|phase gating| lob
+    lob -->|fills - commission| broker[Broker / CommissionModel<br/>max(bps, min_fee)]
+    broker --> lob
+    lob --> snapshot[MarketSnapshot + phase]
+    newsFeed[News Feed<br/>exogenous events e.g. tweets] --> swarm[LLM Swarm]
+    marketNews[Default Market News] --> swarm
     snapshot --> swarm
-    swarm --> retailOrders[RetailSwarmOrders]
-    retailOrders --> lob
+    swarm --> retailOrders[Retail Swarm Orders<br/>w/ time_in_force, optional limit]
+    retailOrders --> broker
 ```
+
+Notes on the updated architecture:
+
+- the LOB is a native Python port of the MASfSES-JADE matching engine
+  (price-time priority, two-phase NoLimit → Limit matching),
+- orders carry extended `price_type`, `time_in_force`, `stop_price`,
+  `expiry_tick` fields so the engine can handle GTD pruning and stop triggering,
+- the accumulation investor emits one small market-buy every
+  `accumulation_days * cycles_per_session` cycles and skips auction windows,
+- the session phase manager runs opening/closing call auctions and rejects
+  orders during `closed` / `pre_open`,
+- the commission layer deducts `max(volume * price * bps / 10_000, min_fee)`
+  at every fill so that transactions on a spread smaller than the commission
+  stop being profitable,
+- the news feed lets external events (e.g. a Trump tweet) interrupt the
+  regular `swarm_update_freq` cadence and feed the swarm out of band.
 
 This means:
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,173 @@
+"""Tests for extended Order, AgentDecision, MarketSnapshot, SimulationConfig."""
+
+from __future__ import annotations
+
+import unittest
+
+from pydantic import ValidationError
+
+from core.models import AgentDecision, MarketSnapshot, Order, SimulationConfig
+
+
+class OrderPriceTypeTests(unittest.TestCase):
+    def test_market_defaults(self) -> None:
+        order = Order(action="buy", volume=1.0)
+        self.assertEqual(order.price_type, "market")
+        self.assertIsNone(order.limit_price)
+        self.assertIsNone(order.stop_price)
+        self.assertEqual(order.time_in_force, "GTC")
+        self.assertIsNone(order.expiry_tick)
+
+    def test_limit_requires_limit_price(self) -> None:
+        Order(action="buy", price_type="limit", volume=1.0, limit_price=100.0)
+        with self.assertRaisesRegex(ValidationError, "limit_price is required"):
+            Order(action="buy", price_type="limit", volume=1.0)
+
+    def test_market_rejects_limit_price(self) -> None:
+        with self.assertRaisesRegex(ValidationError, "limit_price must be omitted"):
+            Order(action="buy", price_type="market", volume=1.0, limit_price=100.0)
+
+    def test_market_rejects_stop_price(self) -> None:
+        with self.assertRaisesRegex(ValidationError, "stop_price must be omitted"):
+            Order(action="buy", price_type="market", volume=1.0, stop_price=95.0)
+
+    def test_stop_market_requires_stop_price(self) -> None:
+        Order(action="buy", price_type="stop_market", volume=1.0, stop_price=105.0)
+        with self.assertRaisesRegex(ValidationError, "stop_price is required"):
+            Order(action="buy", price_type="stop_market", volume=1.0)
+
+    def test_stop_market_rejects_limit_price(self) -> None:
+        with self.assertRaisesRegex(ValidationError, "limit_price must be omitted"):
+            Order(
+                action="buy",
+                price_type="stop_market",
+                volume=1.0,
+                stop_price=105.0,
+                limit_price=110.0,
+            )
+
+    def test_stop_limit_requires_both_prices(self) -> None:
+        Order(
+            action="sell",
+            price_type="stop_limit",
+            volume=1.0,
+            stop_price=95.0,
+            limit_price=94.0,
+        )
+        with self.assertRaisesRegex(ValidationError, "limit_price is required"):
+            Order(action="sell", price_type="stop_limit", volume=1.0, stop_price=95.0)
+        with self.assertRaisesRegex(ValidationError, "stop_price is required"):
+            Order(action="sell", price_type="stop_limit", volume=1.0, limit_price=94.0)
+
+
+class OrderTimeInForceTests(unittest.TestCase):
+    def test_gtd_requires_expiry_tick(self) -> None:
+        Order(action="buy", volume=1.0, time_in_force="GTD", expiry_tick=500)
+        with self.assertRaisesRegex(ValidationError, "expiry_tick is required"):
+            Order(action="buy", volume=1.0, time_in_force="GTD")
+
+    def test_non_gtd_rejects_expiry_tick(self) -> None:
+        for tif in ("GTC", "IOC", "FOK"):
+            with self.assertRaisesRegex(ValidationError, "expiry_tick must be omitted"):
+                Order(action="buy", volume=1.0, time_in_force=tif, expiry_tick=500)
+
+
+class AgentDecisionTests(unittest.TestCase):
+    def test_hold_rejects_extras(self) -> None:
+        AgentDecision(action="hold", volume=0.0)
+        with self.assertRaisesRegex(ValidationError, "Hold decisions cannot set stop_price"):
+            AgentDecision(action="hold", volume=0.0, stop_price=100.0)
+        with self.assertRaisesRegex(ValidationError, "Hold decisions cannot set expiry_tick"):
+            AgentDecision(action="hold", volume=0.0, expiry_tick=500)
+
+    def test_to_order_propagates_new_fields(self) -> None:
+        decision = AgentDecision(
+            action="buy",
+            price_type="stop_limit",
+            volume=2.5,
+            stop_price=105.0,
+            limit_price=106.0,
+            time_in_force="GTD",
+            expiry_tick=1000,
+            source="rl",
+        )
+        order = decision.to_order()
+        self.assertIsNotNone(order)
+        assert order is not None
+        self.assertEqual(order.price_type, "stop_limit")
+        self.assertEqual(order.stop_price, 105.0)
+        self.assertEqual(order.limit_price, 106.0)
+        self.assertEqual(order.time_in_force, "GTD")
+        self.assertEqual(order.expiry_tick, 1000)
+
+    def test_to_order_returns_none_for_hold(self) -> None:
+        self.assertIsNone(AgentDecision(action="hold", volume=0.0).to_order())
+
+    def test_trade_decision_applies_price_rules(self) -> None:
+        with self.assertRaisesRegex(ValidationError, "stop_price is required"):
+            AgentDecision(action="buy", price_type="stop_market", volume=1.0)
+
+
+class MarketSnapshotTests(unittest.TestCase):
+    def test_phase_defaults_to_continuous(self) -> None:
+        snapshot = MarketSnapshot(
+            last_price=100.0, mid_price=100.0, imbalance=0.0, spread=0.2
+        )
+        self.assertEqual(snapshot.phase, "continuous")
+
+    def test_phase_accepts_all_literals(self) -> None:
+        for phase in ("pre_open", "opening_auction", "continuous", "closing_auction", "closed"):
+            snapshot = MarketSnapshot(
+                last_price=100.0,
+                mid_price=100.0,
+                imbalance=0.0,
+                spread=0.2,
+                phase=phase,
+            )
+            self.assertEqual(snapshot.phase, phase)
+
+    def test_invalid_phase_rejected(self) -> None:
+        with self.assertRaises(ValidationError):
+            MarketSnapshot(
+                last_price=100.0,
+                mid_price=100.0,
+                imbalance=0.0,
+                spread=0.2,
+                phase="halted",
+            )
+
+
+class SimulationConfigTests(unittest.TestCase):
+    def test_default_clock_fields(self) -> None:
+        config = SimulationConfig()
+        self.assertEqual(config.ticks_per_session, 1000)
+        self.assertEqual(config.sessions_per_year, 252)
+        self.assertEqual(config.cycles_per_session, 40)
+        self.assertEqual(config.opening_auction_ticks, 20)
+        self.assertEqual(config.closing_auction_ticks, 20)
+        self.assertEqual(config.accumulation_days, 5)
+        self.assertEqual(config.accumulation_volume, 1.0)
+        self.assertEqual(config.commission_bps, 0.0)
+        self.assertEqual(config.commission_min_per_trade, 0.0)
+        self.assertIsNone(config.session_schedule)
+
+    def test_auction_windows_must_fit_session(self) -> None:
+        with self.assertRaisesRegex(ValidationError, "must be <"):
+            SimulationConfig(
+                ticks_per_session=100,
+                opening_auction_ticks=60,
+                closing_auction_ticks=60,
+            )
+
+    def test_custom_session_schedule(self) -> None:
+        config = SimulationConfig(
+            session_schedule=[("opening_auction", 10), ("continuous", 80), ("closing_auction", 10)]
+        )
+        self.assertEqual(
+            config.session_schedule,
+            [("opening_auction", 10), ("continuous", 80), ("closing_auction", 10)],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #2. Część epika #1.

## Zmiany
- `PriceType`: dodane `stop_market` i `stop_limit`; nowe pole `stop_price` na `Order` i `AgentDecision` z walidacją krzyżową.
- `TimeInForce` = GTC/IOC/FOK/GTD + `expiry_tick` z walidacją (GTD wymaga, reszta zabrania).
- `OrderSource` rozszerzone o `institutional`, `accumulation`, `noise` (pod agenty z następnych issues).
- `MarketPhase` literal (pre_open / opening_auction / continuous / closing_auction / closed) + pole `phase` na `MarketSnapshot` (domyślnie `continuous`).
- `SimulationConfig` rozszerzony: `commission_bps`, `commission_min_per_trade`, `ticks_per_session=1000`, `sessions_per_year=252`, `cycles_per_session=40`, `opening_auction_ticks=20`, `closing_auction_ticks=20`, `accumulation_days=5`, `accumulation_volume=1.0`, `session_schedule`. Walidator sprawdza że aukcje mieszczą się w sesji.
- `AgentDecision.to_order()` propaguje wszystkie nowe pola.
- Aktualizacja diagramów w `docs/project_baseline.md` i `docs/running_and_flow.md` — pokazują stop queue, akumulację, fazy sesji, broker i news feed.
- Re-export `MarketPhase`, `PriceType`, `TimeInForce` z `core/__init__.py`.

## Testy
- Nowe `tests/test_models.py` — 19 testów unittest pokrywających wszystkie nowe walidatory i kombinacje pól.
- `python -m unittest tests.test_models tests.test_run_experiment_smoke tests.test_orchestrator_logging` → 23/23 zielone.
- `tests/smoke_test.py` → PPO + MarketEnv bootują bez zmian.

## Test plan
- [x] Nowe unit testy przechodzą
- [x] Istniejące testy integracyjne dalej zielone
- [x] `make smoke` OK
- [x] Żadnych zmian w logice silnika czy orchestratora (tylko schematy i walidatory)